### PR TITLE
Add credit to RPDB in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # Better Covers
-**This is still a WIP!**
+
+**This project was inspired by [Rating Poster Database](https://ratingposterdb.com/)!**
+
+_**This is still a WIP!**_
 
 Script intended to automaticaly generate cover images for Emby/Plex/Jellyfinn library embeded with RT, IMDB, MTS and TMDB scores and media info.  
 It generates an html file with the cover and then makes a png from that file with `cutycapt`, in the future the idea would be to fully integrate this with clients to have the reactive html displayed instead of an image.


### PR DESCRIPTION
As per the [discussion on reddit](https://www.reddit.com/r/jellyfin/comments/m8rxsa/cover_ratings/gsyuhyp?utm_source=share&utm_medium=web2x&context=3), this PR adds a credit note in the readme file for the original project that inspired it.